### PR TITLE
Commenting code - clarify scope for removing commented code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ update accountList;
    - This helps with readability and quality control
 5. One trigger per object 
    - Can’t guarantee which one runs first if not
-6. Never commit commented, obsolete code ***in a final commit -- this branch is done and ready for merge.***  Retaining commented code during development is acceptable for reference or convenience, but purge it before a final commit.
+6. Never commit commented, obsolete code **in a final commit -- this branch is done and ready for merge.**  Retaining commented code during development is acceptable for reference or convenience, but purge it before a final commit.
    - Commenting out code goes against the very reason version control exists; it will still be available by looking at the history
 
 ## (PERSONAL BEST PRACTICES - DISCUSSION COMING LATER)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ update accountList;
    - This helps with readability and quality control
 5. One trigger per object 
    - Can’t guarantee which one runs first if not
-6. Never comment out old code and submit that to version control (commenting out code while during development is fine)
+6. Never commit commented, obsolete code ***in a final commit -- this branch is done and ready for merge.***  Retaining commented code during development is acceptable for reference or convenience, but purge it before a final commit.
    - Commenting out code goes against the very reason version control exists; it will still be available by looking at the history
 
 ## (PERSONAL BEST PRACTICES - DISCUSSION COMING LATER)


### PR DESCRIPTION
I want to encourage people to commit early, commit often, push likewise, and create PRs early for review by team members, increasing the number of eyes on code and likely help identify issues earlier in the process.  Therefore I prefer having softer guidelines for interim code.